### PR TITLE
Fixing false value bug

### DIFF
--- a/lib/types/input.js
+++ b/lib/types/input.js
@@ -2,7 +2,7 @@ import Base from './_base';
 
 export default class InputType extends Base {
   get template() {
-    return '<input type="${type}"<% if(id) { %> id="${id}" name="${id}"<% } %><% if(className) { %> class="${className}"<% } %><% if(typeof value !== "undefined") { %> value="${value}"<% } %><% if(placeholder) { %> placeholder="${placeholder}"<% } %><% if (required) { %> required<% } %>>';
+    return '<input type="${type}"<% if(id) { %> id="${id}" name="${id}"<% } %><% if(className) { %> class="${className}"<% } %><% if(value !== false) { %> value="${value}"<% } %><% if(placeholder) { %> placeholder="${placeholder}"<% } %><% if (required) { %> required<% } %>>';
   }
 
   get defaults() {


### PR DESCRIPTION
Since the default is set to `value: false` the `value` item is never undefined thereby setting the actual value attribute to the literal string "false" during render.